### PR TITLE
prevent duplication of the creation of test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,5 +20,4 @@ add_library(g1fitting
 add_executable(test test.cpp)
 target_link_libraries(test g1fitting)
 
-add_executable(test test.cpp)
 


### PR DESCRIPTION
to prevent the following error:
CMake Error at CMakeLists.txt:23 (add_executable):
  add_executable cannot create target "test" because another target with the
  same name already exists.
